### PR TITLE
README.md: install fonts-inconsolata fonts-migmix for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Ricty 生成スクリプトを配布しています。
 
 Debian/Ubuntu
 
-    # apt-get install fontforge
+    # apt-get install fontforge fonts-inconsolata fonts-migmix
 
 Fedora/CentOS
 


### PR DESCRIPTION
Debian/Ubuntu already contains `Inconsolata.otf`, along with `migu-1m-regular.ttf` and `migu-1m-bold.ttf` in the `fonts-inconsolata` and `fonts-migmix` packages respectively. There's no need to fetch them manually.

I have confirmed that the script finds the required files just fine, at least on Ubuntu 14.04 Trusty.